### PR TITLE
change methods signature ColumnTypeExtension

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,57 @@ UPGRADE
 
 ## Upgrade FROM 0.4 to 0.5
 
+ * The of methods signature of `buildColumn()`, `buildHeaderView()` and `buildCellView()`
+   on the `Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface` was changed
+   to be consistent with the `Rollerworks\Component\Datagrid\Column\ColumnTypeInterface`.
+   
+   Before:
+   
+   ```php
+   /**
+    * @param ColumnInterface $column
+    */
+   public function buildColumn(ColumnInterface $column);
+
+   /**
+    * @param ColumnInterface $column
+    * @param HeaderView      $view
+    */
+   public function buildHeaderView(ColumnInterface $column, HeaderView $view);
+
+   /**
+   * @param ColumnInterface $column
+   * @param CellView        $view
+   */
+   public function buildCellView(ColumnInterface $column, CellView $view);
+   ```
+   
+   After:
+   
+   ```php
+   /**
+    * @param ColumnInterface $column
+    * @param array           $options
+    */
+   public function buildColumn(ColumnInterface $column, array $options);
+   
+   /**
+    * @param HeaderView      $view
+    * @param ColumnInterface $column
+    * @param array           $options
+    */
+   public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options);
+   
+   /**
+    * @param CellView        $view
+    * @param ColumnInterface $column
+    * @param array           $options
+    */
+   public function buildCellView(CellView $view, ColumnInterface $column, array $options);
+   ```
+
+## Upgrade FROM 0.4 to 0.5
+
 ### Field mapping configuration
 
  * The "field_mapping" option now only accepts an associative array,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,7 @@
 UPGRADE
 =======
 
-## Upgrade FROM 0.4 to 0.5
+## Upgrade FROM 0.5 to 0.6
 
  * The of methods signature of `buildColumn()`, `buildHeaderView()` and `buildCellView()`
    on the `Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface` was changed

--- a/src/Column/AbstractColumnTypeExtension.php
+++ b/src/Column/AbstractColumnTypeExtension.php
@@ -16,26 +16,26 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscaps.net>
  */
-abstract class ColumnAbstractTypeExtension implements ColumnTypeExtensionInterface
+abstract class AbstractColumnTypeExtension implements ColumnTypeExtensionInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function buildColumn(ColumnInterface $column)
+    public function buildColumn(ColumnInterface $column, array $options)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildHeaderView(ColumnInterface $column, HeaderView $view)
+    public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildCellView(ColumnInterface $column, CellView $view)
+    public function buildCellView(CellView $view, ColumnInterface $column, array $options)
     {
     }
 

--- a/src/Column/ColumnTypeExtensionInterface.php
+++ b/src/Column/ColumnTypeExtensionInterface.php
@@ -20,20 +20,23 @@ interface ColumnTypeExtensionInterface
 {
     /**
      * @param ColumnInterface $column
+     * @param array           $options
      */
-    public function buildColumn(ColumnInterface $column);
+    public function buildColumn(ColumnInterface $column, array $options);
 
     /**
-     * @param ColumnInterface $column
      * @param HeaderView      $view
+     * @param ColumnInterface $column
+     * @param array           $options
      */
-    public function buildHeaderView(ColumnInterface $column, HeaderView $view);
+    public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options);
 
     /**
-     * @param ColumnInterface $column
      * @param CellView        $view
+     * @param ColumnInterface $column
+     * @param array           $options
      */
-    public function buildCellView(ColumnInterface $column, CellView $view);
+    public function buildCellView(CellView $view, ColumnInterface $column, array $options);
 
     /**
      * Configures the default options for this type.

--- a/src/Column/ResolvedColumnType.php
+++ b/src/Column/ResolvedColumnType.php
@@ -190,7 +190,7 @@ class ResolvedColumnType implements ResolvedColumnTypeInterface
         $this->innerType->buildHeaderView($view, $column, $options);
 
         foreach ($this->typeExtensions as $extension) {
-            $extension->buildHeaderView($column, $view);
+            $extension->buildHeaderView($view, $column, $options);
         }
     }
 
@@ -210,7 +210,7 @@ class ResolvedColumnType implements ResolvedColumnTypeInterface
         $this->innerType->buildCellView($view, $column, $options);
 
         foreach ($this->typeExtensions as $extension) {
-            $extension->buildCellView($column, $view);
+            $extension->buildCellView($view, $column, $options);
         }
     }
 

--- a/src/Extension/Core/ColumnTypeExtension/ColumnOrderExtension.php
+++ b/src/Extension/Core/ColumnTypeExtension/ColumnOrderExtension.php
@@ -11,7 +11,7 @@
 
 namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnTypeExtension;
 
-use Rollerworks\Component\Datagrid\Column\ColumnAbstractTypeExtension;
+use Rollerworks\Component\Datagrid\Column\AbstractColumnTypeExtension;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Column\HeaderView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,12 +22,12 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ColumnOrderExtension extends ColumnAbstractTypeExtension
+class ColumnOrderExtension extends AbstractColumnTypeExtension
 {
     /**
      * {@inheritdoc}
      */
-    public function buildHeaderView(ColumnInterface $column, HeaderView $view)
+    public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options)
     {
         if (!is_null($order = $column->getOption('display_order'))) {
             $view->setAttribute('display_order', $order);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | no |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |

Change the methods signature of `buildColumn()`, `buildHeaderView()` and `buildCellView()`
on the `Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface`
to be consistent with the `Rollerworks\Component\Datagrid\Column\ColumnTypeInterface`.
