### PR TITLE
Use FQCN instead of type-name for column-types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,14 +1,141 @@
 UPGRADE
 =======
 
+## Upgrade FROM 0.6 to 0.7
+
+This version contains BC breaking changes, older versions are no longer supported.
+
+ * Type names were removed. Instead of referencing types by name, you should reference
+   them by their fully-qualified class name (FQCN) instead. With PHP 5.5 or later, you can
+   use the "class" constant for that:
+
+   Before:
+
+   ```php
+   $datagridBuilder->add('name', 'name', ['label' => 'Name');
+   ```
+
+   After:
+
+   ```php
+   use \Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+
+   $datagridBuilder->add('name', TextType::class, ['label' => 'Name');
+   ```
+
+   As a further consequence, the method `ColumnTypeInterface::getName()` was
+   removed. You should remove this method from your types.
+
+   If you want to customize the block prefix of a type in Twig, you should now
+   implement `ColumnTypeInterface::getBlockPrefix()` instead:
+
+   Before:
+
+   ```php
+   class UserProfileType extends AbstractColumnType
+   {
+       public function getName()
+       {
+           return 'profile';
+       }
+   }
+   ```
+
+   After:
+
+   ```php
+   class UserProfileType extends AbstractColumnType
+   {
+       public function getBlockPrefix()
+       {
+           return 'profile';
+       }
+   }
+   ```
+
+   If you don't customize `getBlockPrefix()`, it defaults to the class name
+   without "Type" suffix in underscore notation (here: "user_profile").
+
+   Type extension should return the fully-qualified class name of the extended
+   type from `ColumnTypeExtensionInterface::getExtendedType()` now.
+
+   Before:
+
+   ```php
+   class MyTypeExtension extends AbstractColumnTypeExtension
+   {
+       public function getExtendedType()
+       {
+           return 'column';
+       }
+   }
+   ```
+
+   After:
+
+   ```php
+   use \Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CoumnType;
+
+   class MyTypeExtension extends AbstractColumnTypeExtension
+   {
+       public function getExtendedType()
+       {
+           return CoumnType::class;
+       }
+   }
+   ```
+
+ * Returning type instances from `ColumnTypeInterface::getParent()` is not supported anymore.
+   Return the fully-qualified class name of the parent type class instead.
+
+   Before:
+
+   ```php
+   class MyType extends AbstractColumnType
+   {
+       public function getParent()
+       {
+           return new ParentType();
+       }
+   }
+   ```
+
+   After:
+
+   ```php
+   class MyType extends AbstractColumnType
+   {
+       public function getParent()
+       {
+           return ParentType::class;
+       }
+   }
+   ```
+
+ * Passing type instances to `DatagridBuilder::add()` and the
+   `DatagragridFactory::createCoumn()` methods is not supported anymore.
+   Pass the fully-qualified class name of the type instead.
+
+   Before:
+
+   ```php
+   $column = $datagridBuilder->createColumn(new MyType());
+   ```
+
+   After:
+
+   ```php
+   $column = $datagridBuilder->createColumn(MyType::class);
+   ```
+
 ## Upgrade FROM 0.5 to 0.6
 
  * The of methods signature of `buildColumn()`, `buildHeaderView()` and `buildCellView()`
    on the `Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface` was changed
    to be consistent with the `Rollerworks\Component\Datagrid\Column\ColumnTypeInterface`.
-   
+
    Before:
-   
+
    ```php
    /**
     * @param ColumnInterface $column
@@ -27,23 +154,23 @@ UPGRADE
    */
    public function buildCellView(ColumnInterface $column, CellView $view);
    ```
-   
+
    After:
-   
+
    ```php
    /**
     * @param ColumnInterface $column
     * @param array           $options
     */
    public function buildColumn(ColumnInterface $column, array $options);
-   
+
    /**
     * @param HeaderView      $view
     * @param ColumnInterface $column
     * @param array           $options
     */
    public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options);
-   
+
    /**
     * @param CellView        $view
     * @param ColumnInterface $column
@@ -59,12 +186,12 @@ UPGRADE
  * The "field_mapping" option now only accepts an associative array,
    where the key is used to identify a mapping-field, the value holds
    the mapping-path.
- 
+
    Before: `['field_mapping' => ['user.id']]`
    After: `['field_mapping' => ['user_id' => 'user.id', 'id' => 'id']]`
-   
+
  * Column types with multiple fields will receive the data like:
- 
+
    ```php
    // Keys are as configured (shown above)
    $values = [
@@ -75,24 +202,24 @@ UPGRADE
 
 ### ActionType
 
-The "action" type has been completely rewritten to be more extendible.
+The "action" type has been completely rewritten to be more extensible.
 
  * Option "content" was added as an alternative to the "label" option,
    you can use eg. the "label" option or "content".
-   
+
  * Option "url" was added and allows to configure a complete uri (instead of a pattern).
- 
+
  * Option "uri_scheme" now uses `strtr()` instead of the `sprintf()` pattern
    for formatting an uri.
-   
+
    The replacement values are provided as `{id}` for the `id` mapping key
    (see above for details).
- 
+
  * Instead of configuring multiple actions, you must now use the "compound_column"
    type to combine multiple actions in a cell.
-  
+
    Before:
-   
+
    ```php
    $datagrid->addColumn(
        $this->factory->createColumn(
@@ -116,9 +243,9 @@ The "action" type has been completely rewritten to be more extendible.
        )
    );
    ```
-   
+
    After:
-   
+
    ```php
    $datagrid->addColumn(
        $this->factory->createColumn(
@@ -157,7 +284,7 @@ The "action" type has been completely rewritten to be more extendible.
 ## Upgrade FROM 0.3 to 0.4
 
  * No changes required.
- 
+
 ## Upgrade FROM 0.2 to 0.3
 
  * The methods `setVar()`, `getVar()` and `getVars()` were added

--- a/src/AbstractDatagridExtension.php
+++ b/src/AbstractDatagridExtension.php
@@ -26,14 +26,14 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      *
      * @var array
      */
-    protected $columnTypesExtensions;
+    private $columnTypesExtensions;
 
     /**
      * All column types provided by extension.
      *
      * @var array
      */
-    protected $columnTypes;
+    private $columnTypes;
 
     /**
      * {@inheritdoc}
@@ -68,7 +68,7 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     public function hasColumnTypeExtensions($type)
     {
-        if (!isset($this->columnTypesExtensions)) {
+        if (null === $this->columnTypesExtensions) {
             $this->initColumnTypesExtensions();
         }
 
@@ -80,15 +80,11 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     public function getColumnTypeExtensions($type)
     {
-        if (!isset($this->columnTypesExtensions)) {
+        if (null === $this->columnTypesExtensions) {
             $this->initColumnTypesExtensions();
         }
 
-        if (!isset($this->columnTypesExtensions[$type])) {
-            throw new InvalidArgumentException(sprintf('Extension for column type "%s" can not be loaded by this Datagrid extension.', $type));
-        }
-
-        return $this->columnTypesExtensions[$type];
+        return isset($this->columnTypesExtensions[$type]) ? $this->columnTypesExtensions[$type] : [];
     }
 
     /**
@@ -96,7 +92,6 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     public function registerListeners(DatagridInterface $datagrid)
     {
-        // noop
     }
 
     /**
@@ -145,15 +140,14 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     private function initColumnTypes()
     {
-        $this->columnTypes = [];
-        $columnTypes = $this->loadColumnTypes();
+        $this->columnTypes = array();
 
-        foreach ($columnTypes as $columnType) {
-            if (!$columnType instanceof ColumnTypeInterface) {
-                throw new UnexpectedTypeException($columnType, ColumnTypeInterface::class);
+        foreach ($this->loadColumnTypes() as $type) {
+            if (!$type instanceof ColumnTypeInterface) {
+                throw new UnexpectedTypeException($type, ColumnTypeInterface::class);
             }
 
-            $this->columnTypes[$columnType->getName()] = $columnType;
+            $this->columnTypes[get_class($type)] = $type;
         }
     }
 
@@ -162,18 +156,14 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     private function initColumnTypesExtensions()
     {
-        $columnTypesExtensions = $this->loadColumnTypesExtensions();
+        $this->columnTypesExtensions = [];
 
-        foreach ($columnTypesExtensions as $extension) {
+        foreach ($this->loadColumnTypesExtensions() as $extension) {
             if (!$extension instanceof ColumnTypeExtensionInterface) {
                 throw new UnexpectedTypeException($extension, ColumnTypeExtensionInterface::class);
             }
 
             $type = $extension->getExtendedType();
-
-            if (!isset($this->columnTypesExtensions)) {
-                $this->columnTypesExtensions[$type] = [];
-            }
 
             $this->columnTypesExtensions[$type][] = $extension;
         }

--- a/src/Column/AbstractColumnType.php
+++ b/src/Column/AbstractColumnType.php
@@ -11,6 +11,8 @@
 
 namespace Rollerworks\Component\Datagrid\Column;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ColumnType;
+use Rollerworks\Component\Datagrid\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -47,10 +49,23 @@ abstract class AbstractColumnType implements ColumnTypeInterface
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefixes default to the underscored short class name with
+     * the "Type" suffix removed (e.g. "DatetimeType" => "datetime").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return StringUtil::fqcnToBlockPrefix(get_class($this));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getParent()
     {
-        return 'column';
+        return ColumnType::class;
     }
 }

--- a/src/Column/CellView.php
+++ b/src/Column/CellView.php
@@ -81,7 +81,7 @@ class CellView
         $this->column = $column;
         $this->datagrid = $datagrid;
 
-        $this->type = $column->getType()->getName();
+        $this->prefix = $column->getType()->getBlockPrefix();
         $this->name = $column->getName();
     }
 }

--- a/src/Column/ColumnTypeInterface.php
+++ b/src/Column/ColumnTypeInterface.php
@@ -52,14 +52,14 @@ interface ColumnTypeInterface
     public function buildHeaderView(HeaderView $view, ColumnInterface $column, array $options);
 
     /**
-     * Get the name of the column type.
+     * Returns the prefix of the template block name for this type.
      *
-     * @return string
+     * @return string The prefix of the template block name.
      */
-    public function getName();
+    public function getBlockPrefix();
 
     /**
-     * Returns the name of the parent type.
+     * Returns the fully-qualified class name of the parent type.
      *
      * @return string|null The name of the parent type if any, null otherwise.
      */

--- a/src/Column/HeaderView.php
+++ b/src/Column/HeaderView.php
@@ -59,7 +59,7 @@ class HeaderView
         $this->datagrid = $datagrid;
         $this->label = $label;
 
-        $this->type = $column->getType()->getName();
+        $this->prefix = $column->getType()->getBlockPrefix();
         $this->name = $column->getName();
     }
 

--- a/src/Column/ResolvedColumnType.php
+++ b/src/Column/ResolvedColumnType.php
@@ -55,14 +55,6 @@ class ResolvedColumnType implements ResolvedColumnTypeInterface
      */
     public function __construct(ColumnTypeInterface $innerType, array $typeExtensions = [], ResolvedColumnTypeInterface $parent = null)
     {
-        if (!preg_match('/^[a-z0-9_]*$/i', $innerType->getName())) {
-            throw new InvalidArgumentException(sprintf(
-                'The "%s" column type name ("%s") is not valid. Names must only contain letters, numbers, and "_".',
-                get_class($innerType),
-                $innerType->getName()
-            ));
-        }
-
         foreach ($typeExtensions as $extension) {
             if (!$extension instanceof ColumnTypeExtensionInterface) {
                 throw new UnexpectedTypeException($extension, 'Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface');
@@ -75,13 +67,11 @@ class ResolvedColumnType implements ResolvedColumnTypeInterface
     }
 
     /**
-     * Returns the name of the type.
-     *
-     * @return string The type name
+     * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
-        return $this->innerType->getName();
+        return $this->innerType->getBlockPrefix();
     }
 
     /**

--- a/src/Column/ResolvedColumnTypeInterface.php
+++ b/src/Column/ResolvedColumnTypeInterface.php
@@ -22,11 +22,11 @@ use Rollerworks\Component\Datagrid\DatagridViewInterface;
 interface ResolvedColumnTypeInterface
 {
     /**
-     * Returns the name of the type.
+     * Returns the prefix of the template block name for this type.
      *
-     * @return string The type name.
+     * @return string The prefix of the template block name.
      */
-    public function getName();
+    public function getBlockPrefix();
 
     /**
      * Returns the parent type.

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -169,7 +169,7 @@ class Datagrid implements DatagridInterface
     public function hasColumnType($type)
     {
         foreach ($this->columns as $column) {
-            if ($column->getType()->getName() === $type) {
+            if ($column->getType()->getInnerType() instanceof $type) {
                 return true;
             }
         }

--- a/src/Extension/Core/ColumnType/ActionType.php
+++ b/src/Extension/Core/ColumnType/ActionType.php
@@ -27,14 +27,6 @@ class ActionType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'action';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildCellView(CellView $view, ColumnInterface $column, array $options)
     {
         $mappingValues = $view->value;

--- a/src/Extension/Core/ColumnType/BatchType.php
+++ b/src/Extension/Core/ColumnType/BatchType.php
@@ -21,14 +21,6 @@ class BatchType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'batch';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildCellView(CellView $view, ColumnInterface $column, array $options)
     {
         $view->attributes['datagrid_name'] = $column->getDatagrid()->getName();

--- a/src/Extension/Core/ColumnType/BooleanType.php
+++ b/src/Extension/Core/ColumnType/BooleanType.php
@@ -24,17 +24,9 @@ class BooleanType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'boolean';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getParent()
     {
-        return 'text';
+        return TextType::class;
     }
 
     /**

--- a/src/Extension/Core/ColumnType/ColumnType.php
+++ b/src/Extension/Core/ColumnType/ColumnType.php
@@ -16,6 +16,7 @@ use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Column\ColumnTypeInterface;
 use Rollerworks\Component\Datagrid\Column\HeaderView;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\SingleMappingTransformer;
+use Rollerworks\Component\Datagrid\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -74,16 +75,17 @@ class ColumnType implements ColumnTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getParent()
     {
-        return 'column';
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the prefix of the template block name for this type.
+     *
+     * @return string The prefix of the template block name.
      */
-    public function getParent()
+    public function getBlockPrefix()
     {
-        return;
+        return StringUtil::fqcnToBlockPrefix(get_class($this));
     }
 }

--- a/src/Extension/Core/ColumnType/CompoundColumnType.php
+++ b/src/Extension/Core/ColumnType/CompoundColumnType.php
@@ -28,14 +28,6 @@ class CompoundColumnType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'compound_column';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getParent()
     {
         return;

--- a/src/Extension/Core/ColumnType/DateTimeType.php
+++ b/src/Extension/Core/ColumnType/DateTimeType.php
@@ -47,14 +47,6 @@ class DateTimeType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'datetime';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildColumn(ColumnInterface $column, array $options)
     {
         $dateFormat = is_int($options['date_format']) ? $options['date_format'] : self::DEFAULT_DATE_FORMAT;

--- a/src/Extension/Core/ColumnType/ModelType.php
+++ b/src/Extension/Core/ColumnType/ModelType.php
@@ -29,14 +29,6 @@ class ModelType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'model';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildColumn(ColumnInterface $column, array $options)
     {
         if (count($options['field_mapping']) > 2) {

--- a/src/Extension/Core/ColumnType/MoneyType.php
+++ b/src/Extension/Core/ColumnType/MoneyType.php
@@ -21,14 +21,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class MoneyType extends AbstractColumnType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'money';
-    }
-
     public function buildColumn(ColumnInterface $column, array $options)
     {
         $column

--- a/src/Extension/Core/ColumnType/NumberType.php
+++ b/src/Extension/Core/ColumnType/NumberType.php
@@ -22,14 +22,6 @@ class NumberType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'number';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildColumn(ColumnInterface $column, array $options)
     {
         $column->addViewTransformer(new NumberToLocalizedStringTransformer(

--- a/src/Extension/Core/ColumnType/TextType.php
+++ b/src/Extension/Core/ColumnType/TextType.php
@@ -23,14 +23,6 @@ class TextType extends AbstractColumnType
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'text';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildColumn(ColumnInterface $column, array $options)
     {
         if ($options['trim']) {

--- a/src/Extension/Core/ColumnTypeExtension/ColumnOrderExtension.php
+++ b/src/Extension/Core/ColumnTypeExtension/ColumnOrderExtension.php
@@ -14,6 +14,7 @@ namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnTypeExtension;
 use Rollerworks\Component\Datagrid\Column\AbstractColumnTypeExtension;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Column\HeaderView;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ColumnType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -39,7 +40,7 @@ class ColumnOrderExtension extends AbstractColumnTypeExtension
      */
     public function getExtendedType()
     {
-        return 'column';
+        return ColumnType::class;
     }
 
     /**

--- a/src/Extension/Core/ColumnTypeExtension/CompoundColumnOrderExtension.php
+++ b/src/Extension/Core/ColumnTypeExtension/CompoundColumnOrderExtension.php
@@ -11,6 +11,8 @@
 
 namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnTypeExtension;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CompoundColumnType;
+
 /**
  * Allows to set the compound-column sorting order.
  *
@@ -23,6 +25,6 @@ class CompoundColumnOrderExtension extends ColumnOrderExtension
      */
     public function getExtendedType()
     {
-        return 'compound_column';
+        return CompoundColumnType::class;
     }
 }

--- a/src/Test/DatagridIntegrationTestCase.php
+++ b/src/Test/DatagridIntegrationTestCase.php
@@ -32,7 +32,7 @@ abstract class DatagridIntegrationTestCase extends \PHPUnit_Framework_TestCase
         $extensions = array_merge($extensions, $this->getExtensions());
 
         $typesRegistry = new ColumnTypeRegistry($extensions, $resolvedTypeFactory);
-        $this->factory = new DatagridFactory($typesRegistry, $resolvedTypeFactory, new PropertyAccessorMapper());
+        $this->factory = new DatagridFactory($typesRegistry, new PropertyAccessorMapper());
     }
 
     protected function getExtensions()

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rollerworks\Component\Datagrid\Util;
+
+/**
+ * @author Issei Murasawa <issei.m7@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+final class StringUtil
+{
+    /**
+     * This class should not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns the trimmed data.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function trim($string)
+    {
+        if (null !== $result = @preg_replace('/^[\pZ\p{Cc}]+|[\pZ\p{Cc}]+$/u', '', $string)) {
+            return $result;
+        }
+
+        return trim($string);
+    }
+
+    /**
+     * Converts a fully-qualified class name to a block prefix.
+     *
+     * @param string $fqcn The fully-qualified class name
+     *
+     * @return string|null The block prefix or null if not a valid FQCN
+     */
+    public static function fqcnToBlockPrefix($fqcn)
+    {
+        // Non-greedy ("+?") to match "type" suffix, if present
+        if (preg_match('~([^\\\\]+?)(type)?$~i', $fqcn, $matches)) {
+            return strtolower(
+                preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], $matches[1])
+            );
+        }
+    }
+}

--- a/tests/DatagridBuilderTest.php
+++ b/tests/DatagridBuilderTest.php
@@ -17,6 +17,8 @@ use Rollerworks\Component\Datagrid\DatagridBuilder;
 use Rollerworks\Component\Datagrid\DatagridFactoryInterface;
 use Rollerworks\Component\Datagrid\DatagridInterface;
 use Rollerworks\Component\Datagrid\DataMapper\DataMapperInterface;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
 
 final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -47,12 +49,12 @@ final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
             return $column->reveal();
         };
 
-        $this->factory->createColumn('id', 'number', Argument::any(), [])->will($columnCreator)->shouldBeCalled();
-        $this->factory->createColumn('name', 'text', Argument::any(), ['format' => '%s'])->will($columnCreator)->shouldBeCalled();
+        $this->factory->createColumn('id', NumberType::class, Argument::any(), [])->will($columnCreator)->shouldBeCalled();
+        $this->factory->createColumn('name', TextType::class, Argument::any(), ['format' => '%s'])->will($columnCreator)->shouldBeCalled();
 
         $grid = new DatagridBuilder($this->factory->reveal(), 'grid', $this->dataMapper);
-        $grid->add('id', 'number');
-        $grid->add('name', 'text', ['format' => '%s']);
+        $grid->add('id', NumberType::class);
+        $grid->add('name', TextType::class, ['format' => '%s']);
 
         $this->assertInstanceOf(DatagridInterface::class, $grid->getDatagrid());
     }

--- a/tests/DatagridFactoryTest.php
+++ b/tests/DatagridFactoryTest.php
@@ -19,6 +19,7 @@ use Rollerworks\Component\Datagrid\DatagridBuilderInterface;
 use Rollerworks\Component\Datagrid\DatagridFactory;
 use Rollerworks\Component\Datagrid\DatagridInterface;
 use Rollerworks\Component\Datagrid\DataMapper\DataMapperInterface;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
 
 class DatagridFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,7 +49,7 @@ class DatagridFactoryTest extends \PHPUnit_Framework_TestCase
         $this->resolvedTypeFactory = $this->getMock(ResolvedColumnTypeFactoryInterface::class);
         $this->dataMapper = $this->getMock(DataMapperInterface::class);
 
-        $this->factory = new DatagridFactory($this->registry, $this->resolvedTypeFactory, $this->dataMapper);
+        $this->factory = new DatagridFactory($this->registry, $this->dataMapper);
     }
 
     public function testCreateGrid()
@@ -87,10 +88,10 @@ class DatagridFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->registry
             ->expects($this->once())
-            ->method('getType')->with('text')
+            ->method('getType')->with(TextType::class)
             ->will($this->returnValue($type));
 
-        $this->assertEquals($column, $this->factory->createColumn('id', 'text', $grid, ['foo' => 'bar']));
+        $this->assertEquals($column, $this->factory->createColumn('id', TextType::class, $grid, ['foo' => 'bar']));
     }
 
     public function testGetDataMapper()

--- a/tests/DatagridPerformanceTest.php
+++ b/tests/DatagridPerformanceTest.php
@@ -12,6 +12,9 @@
 namespace Rollerworks\Component\Datagrid\Tests;
 
 use Rollerworks\Component\Datagrid\DatagridViewInterface;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\DateTimeType;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
 use Rollerworks\Component\Datagrid\Test\DatagridPerformanceTestCase;
 
 class DatagridPerformanceTest extends DatagridPerformanceTestCase
@@ -32,15 +35,15 @@ class DatagridPerformanceTest extends DatagridPerformanceTestCase
 
         $datagrid = $this->factory->createDatagrid('test');
 
-        $datagrid->addColumn($this->factory->createColumn('id', 'number', $datagrid, ['label' => '#', 'field_mapping' => ['id']]));
-        $datagrid->addColumn($this->factory->createColumn('name', 'text', $datagrid, ['label' => 'Name', 'field_mapping' => ['name']]));
-        $datagrid->addColumn($this->factory->createColumn('email', 'text', $datagrid, ['label' => 'Email', 'field_mapping' => ['email']]));
-        $datagrid->addColumn($this->factory->createColumn('regdate', 'datetime', $datagrid, ['label' => 'regdate', 'field_mapping' => ['regdate']]));
-        $datagrid->addColumn($this->factory->createColumn('last_modified', 'datetime', $datagrid, ['label' => 'last_modified', 'field_mapping' => ['lastModified']]));
+        $datagrid->addColumn($this->factory->createColumn('id', NumberType::class, $datagrid, ['label' => '#', 'field_mapping' => ['id']]));
+        $datagrid->addColumn($this->factory->createColumn('name', TextType::class, $datagrid, ['label' => 'Name', 'field_mapping' => ['name']]));
+        $datagrid->addColumn($this->factory->createColumn('email', TextType::class, $datagrid, ['label' => 'Email', 'field_mapping' => ['email']]));
+        $datagrid->addColumn($this->factory->createColumn('regdate', DateTimeType::class, $datagrid, ['label' => 'regdate', 'field_mapping' => ['regdate']]));
+        $datagrid->addColumn($this->factory->createColumn('last_modified', DateTimeType::class, $datagrid, ['label' => 'last_modified', 'field_mapping' => ['lastModified']]));
         $datagrid->addColumn(
             $this->factory->createColumn(
                 'status',
-                'text',
+                TextType::class,
                 $datagrid,
                 [
                     'label' => 'last_modified',
@@ -51,7 +54,7 @@ class DatagridPerformanceTest extends DatagridPerformanceTestCase
                 ]
             )
         );
-        $datagrid->addColumn($this->factory->createColumn('group', 'text', $datagrid, ['label' => 'group', 'field_mapping' => ['group']]));
+        $datagrid->addColumn($this->factory->createColumn('group', TextType::class, $datagrid, ['label' => 'group', 'field_mapping' => ['group']]));
 
         $datagrid->addColumn(
             $this->factory->createColumn(

--- a/tests/DatagridTest.php
+++ b/tests/DatagridTest.php
@@ -18,7 +18,9 @@ use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface;
 use Rollerworks\Component\Datagrid\Datagrid;
 use Rollerworks\Component\Datagrid\DatagridViewInterface;
 use Rollerworks\Component\Datagrid\DataMapper\DataMapperInterface;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
 use Rollerworks\Component\Datagrid\Tests\Fixtures\Entity;
+use Rollerworks\Component\Datagrid\Util\StringUtil;
 
 class DatagridTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,8 +55,6 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
                     case 'name':
                        return $object->setName($value);
                 }
-
-                return;
             }));
 
         $this->datagrid = new Datagrid('grid', $this->dataMapper);
@@ -67,10 +67,11 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
      *
      * @return ResolvedColumnTypeInterface|\Prophecy\Prophecy\ObjectProphecy
      */
-    private function createColumn($name = 'foo1', $typeName = 'text', $reveal = true)
+    private function createColumn($name = 'foo1', $typeName = TextType::class, $reveal = true)
     {
         $type = $this->prophesize(ResolvedColumnTypeInterface::class);
-        $type->getName()->willReturn($typeName);
+        $type->getInnerType()->willReturn(new $typeName());
+        $type->getBlockPrefix()->willReturn(StringUtil::fqcnToBlockPrefix($typeName));
 
         $column = $this->prophesize(ColumnInterface::class);
         $column->getName()->willReturn($name);
@@ -93,7 +94,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->datagrid->addColumn($this->createColumn());
 
         $this->assertTrue($this->datagrid->hasColumn('foo1'));
-        $this->assertTrue($this->datagrid->hasColumnType('text'));
+        $this->assertTrue($this->datagrid->hasColumnType(TextType::class));
 
         $this->assertFalse($this->datagrid->hasColumn('foo2'));
         $this->assertFalse($this->datagrid->hasColumnType('this_type_cant_exists'));
@@ -122,7 +123,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testSetData()
     {
-        $column = $this->createColumn('foo1', 'text', false);
+        $column = $this->createColumn('foo1', TextType::class, false);
         $column->createHeaderView(Argument::any(), Argument::any())->will(
             function ($args) use ($column) {
                 return new HeaderView($column->reveal(), $args[0], 'foo1');
@@ -183,7 +184,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ['next', 'data'],
         ];
 
-        $column = $this->createColumn('foo1', 'text', false);
+        $column = $this->createColumn('foo1', TextType::class, false);
 
         $column->bindData($bindData[0], $gridData[0], 0)->shouldBeCalled();
         $column->bindData($bindData[0], $gridData[0], 0)->shouldBeCalled();
@@ -215,7 +216,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ['next', 'data'],
         ];
 
-        $column = $this->createColumn('foo1', 'text', false);
+        $column = $this->createColumn('foo1', TextType::class, false);
 
         $column->bindData($bindData[0], $gridData[0], 0)->shouldBeCalled();
         $column->bindData($bindData[0], $gridData[0], 0)->shouldBeCalled();
@@ -244,7 +245,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateView()
     {
-        $column = $this->createColumn('foo1', 'text', false);
+        $column = $this->createColumn('foo1', TextType::class, false);
         $column->createHeaderView(Argument::any(), Argument::any())->will(
             function ($args) use ($column) {
                 return new HeaderView($column->reveal(), $args[0], 'foo1');

--- a/tests/DatagridViewTest.php
+++ b/tests/DatagridViewTest.php
@@ -34,9 +34,6 @@ class DatagridViewTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $type = $this->getMock(ResolvedColumnTypeInterface::class);
-        $type->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('text'));
 
         $datagrid = $this->getMock(DatagridInterface::class);
         $column = $this->getMock(ColumnInterface::class);
@@ -89,9 +86,6 @@ class DatagridViewTest extends \PHPUnit_Framework_TestCase
     public function testAddColumn()
     {
         $type = $this->getMock('Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface');
-        $type->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('text'));
 
         $column = $this->getMock('Rollerworks\Component\Datagrid\Column\ColumnInterface');
         $column->expects($this->any())
@@ -113,9 +107,6 @@ class DatagridViewTest extends \PHPUnit_Framework_TestCase
     public function testRemoveColumn()
     {
         $type = $this->getMock('Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface');
-        $type->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('text'));
 
         $column = $this->getMock('Rollerworks\Component\Datagrid\Column\ColumnInterface');
         $column->expects($this->any())
@@ -138,9 +129,6 @@ class DatagridViewTest extends \PHPUnit_Framework_TestCase
     public function testClearColumns()
     {
         $type = $this->getMock('Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface');
-        $type->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('text'));
 
         $column = $this->getMock('Rollerworks\Component\Datagrid\Column\ColumnInterface');
         $column->expects($this->any())

--- a/tests/Extension/Core/ColumnType/ActionTypeTest.php
+++ b/tests/Extension/Core/ColumnType/ActionTypeTest.php
@@ -11,11 +11,13 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ActionType;
+
 class ActionTypeTest extends BaseTypeTest
 {
     protected function getTestedType()
     {
-        return 'action';
+        return ActionType::class;
     }
 
     public function testPassLabelToView()

--- a/tests/Extension/Core/ColumnType/BooleanTest.php
+++ b/tests/Extension/Core/ColumnType/BooleanTest.php
@@ -11,11 +11,13 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\BooleanType;
+
 class BooleanTest extends BaseTypeTest
 {
     protected function getTestedType()
     {
-        return 'boolean';
+        return BooleanType::class;
     }
 
     public function testBasicValue()

--- a/tests/Extension/Core/ColumnType/CompoundColumnTypeTest.php
+++ b/tests/Extension/Core/ColumnType/CompoundColumnTypeTest.php
@@ -13,12 +13,15 @@ namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CompoundColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
 
 class CompoundColumnTypeTest extends BaseTypeTest
 {
     protected function getTestedType()
     {
-        return 'compound_column';
+        return CompoundColumnType::class;
     }
 
     public function testPassLabelToView()
@@ -38,8 +41,8 @@ class CompoundColumnTypeTest extends BaseTypeTest
     public function testSubCellsToView()
     {
         $columns = [];
-        $columns['age'] = $this->factory->createColumn('age', 'number', $this->datagrid, ['label' => 'Age', 'field_mapping' => ['age']]);
-        $columns['name'] = $this->factory->createColumn('name', 'text', $this->datagrid, ['label' => 'Name', 'trim' => true, 'field_mapping' => ['name']]);
+        $columns['age'] = $this->factory->createColumn('age', NumberType::class, $this->datagrid, ['label' => 'Age', 'field_mapping' => ['age']]);
+        $columns['name'] = $this->factory->createColumn('name', TextType::class, $this->datagrid, ['label' => 'Name', 'trim' => true, 'field_mapping' => ['name']]);
 
         $column = $this->factory->createColumn(
             'actions',
@@ -86,7 +89,7 @@ class CompoundColumnTypeTest extends BaseTypeTest
         $this->datagrid->setData([1 => $object]);
 
         $columns = [];
-        $columns['age'] = $this->factory->createColumn('age', 'number', $this->datagrid, ['label' => 'My label', 'field_mapping' => ['age']]);
+        $columns['age'] = $this->factory->createColumn('age', NumberType::class, $this->datagrid, ['label' => 'My label', 'field_mapping' => ['age']]);
         $columns['foo'] = false;
         $options['columns'] = $columns;
 
@@ -97,7 +100,7 @@ class CompoundColumnTypeTest extends BaseTypeTest
 
         $datagridView = $this->datagrid->createView();
 
-        $this->factory->createColumn('birthday', 'compound_column', $this->datagrid, $options)->createCellView(
+        $this->factory->createColumn('birthday', CompoundColumnType::class, $this->datagrid, $options)->createCellView(
             $datagridView,
             $object,
             0

--- a/tests/Extension/Core/ColumnType/DateTimeTypeTest.php
+++ b/tests/Extension/Core/ColumnType/DateTimeTypeTest.php
@@ -11,13 +11,14 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\DateTimeType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTimeTypeTest extends BaseTypeTest
 {
     protected function getTestedType()
     {
-        return 'datetime';
+        return DateTimeType::class;
     }
 
     protected function setUp()

--- a/tests/Extension/Core/ColumnType/ModelTypeTest.php
+++ b/tests/Extension/Core/ColumnType/ModelTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ModelType;
+
 class ModelTypeTest extends BaseTypeTest
 {
     public function testPassLabelToView()
@@ -120,6 +122,6 @@ class ModelTypeTest extends BaseTypeTest
 
     protected function getTestedType()
     {
-        return 'model';
+        return ModelType::class;
     }
 }

--- a/tests/Extension/Core/ColumnType/MoneyTypeTest.php
+++ b/tests/Extension/Core/ColumnType/MoneyTypeTest.php
@@ -11,13 +11,14 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\MoneyType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyTypeTest extends BaseTypeTest
 {
     protected function getTestedType()
     {
-        return 'money';
+        return MoneyType::class;
     }
 
     protected function setUp()

--- a/tests/Extension/Core/ColumnType/NumberTypeTest.php
+++ b/tests/Extension/Core/ColumnType/NumberTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class NumberTypeTest extends BaseTypeTest
@@ -27,7 +28,7 @@ class NumberTypeTest extends BaseTypeTest
 
     protected function getTestedType()
     {
-        return 'number';
+        return NumberType::class;
     }
 
     public function testDefaultFormatting()
@@ -47,6 +48,10 @@ class NumberTypeTest extends BaseTypeTest
 
     public function testDefaultFormattingWithRounding()
     {
-        $this->assertCellValueEquals('12346', '12345.54321', ['precision' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP]);
+        $this->assertCellValueEquals(
+            '12346',
+            '12345.54321',
+            ['precision' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP]
+        );
     }
 }

--- a/tests/Extension/Core/ColumnType/TextTypeTest.php
+++ b/tests/Extension/Core/ColumnType/TextTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
 
+use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+
 class TextTypeTest extends BaseTypeTest
 {
     public function testTrimOption()
@@ -102,6 +104,6 @@ class TextTypeTest extends BaseTypeTest
 
     protected function getTestedType()
     {
-        return 'text';
+        return TextType::class;
     }
 }

--- a/tests/Extension/Core/EventListener/ColumnOrderListenerTest.php
+++ b/tests/Extension/Core/EventListener/ColumnOrderListenerTest.php
@@ -68,9 +68,6 @@ class ColumnOrderListenerTest extends \PHPUnit_Framework_TestCase
         $columns = [];
 
         $type = $this->getMock('Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface');
-        $type->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('text'));
 
         foreach ($inputColumns as $name => $order) {
             $column = $this->getMock('Rollerworks\Component\Datagrid\Column\ColumnInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |

Use FQCN instead of type-name for column-types (as done in Symfony 3).
This simplifies the internal logic and makes the system slightly faster.
