### PR TITLE
Drop support for Symfony 2.3 OptionsResolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
         - $HOME/.composer/cache
 
 install:
-    - export SYMFONY_DEPRECATIONS_HELPER=weak
+    - export SYMFONY_DEPRECATIONS_HELPER=strong
     - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ "$DEPENDENCIES" != "low" ]; then travis_retry composer update; fi;
     - if [ "$DEPENDENCIES" == "low" ]; then travis_retry composer update --prefer-lowest; fi;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -128,6 +128,10 @@ This version contains BC breaking changes, older versions are no longer supporte
    $column = $datagridBuilder->createColumn(MyType::class);
    ```
 
+ * Support for Symfony 2.3 was dropped, the options-resolver requires at
+   minimum Symfony 2.7 now. Symfony 3 is now allowed to be installed, and
+   will be used unless any of your composer.json packages restricts this version.
+
 ## Upgrade FROM 0.5 to 0.6
 
  * The of methods signature of `buildColumn()`, `buildHeaderView()` and `buildCellView()`

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "symfony/event-dispatcher": "~2.3|~3.0",
         "symfony/property-access": "~2.3|~3.0",
         "symfony/options-resolver": "~2.7.7|~3.0",
-        "symfony/intl": "~2.3|~3.0",
-        "fsi/reflection": "0.9.*"
+        "symfony/intl": "~2.3|~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "symfony/event-dispatcher": "~2.3",
-        "symfony/property-access": "~2.3",
-        "symfony/options-resolver": "~2.3",
-        "symfony/intl": "~2.3",
-        "fsi/reflection": "0.9.*",
-        "fsi/data-indexer": "0.9.*"
+        "php": "~5.5|~7.0",
+        "symfony/event-dispatcher": "~2.3|~3.0",
+        "symfony/property-access": "~2.3|~3.0",
+        "symfony/options-resolver": "~2.7.7|~3.0",
+        "symfony/intl": "~2.3|~3.0",
+        "fsi/reflection": "0.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -32,9 +31,6 @@
         "psr-4": {
             "Rollerworks\\Component\\Datagrid\\Tests\\": "tests/"
         }
-    },
-    "config": {
-        "bin-dir": "bin"
     },
     "extra": {
         "branch-alias": {

--- a/src/Extension/Core/ColumnType/ActionType.php
+++ b/src/Extension/Core/ColumnType/ActionType.php
@@ -16,7 +16,6 @@ use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
@@ -91,23 +90,12 @@ class ActionType extends AbstractColumnType
             ]
         );
 
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'redirect_uri' => ['string', 'null', 'callable'],
-                    'uri_scheme' => ['string', 'callable'],
-                    'content' => ['null', 'string', 'callable'],
-                    'attr' => ['array'],
-                    'url_attr' => ['array'],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('redirect_uri', ['string', 'null', 'callable']);
-            $resolver->setAllowedTypes('uri_scheme', ['string', 'callable']);
-            $resolver->setAllowedTypes('content', ['null', 'string', 'callable']);
-            $resolver->setAllowedTypes('attr', ['array']);
-            $resolver->setAllowedTypes('url_attr', ['array']);
-        }
+        $resolver->setAllowedTypes('redirect_uri', ['string', 'null', 'callable']);
+        $resolver->setAllowedTypes('uri_scheme', ['string', 'callable']);
+        $resolver->setAllowedTypes('content', ['null', 'string', 'callable']);
+        $resolver->setAllowedTypes('attr', ['array']);
+        $resolver->setAllowedTypes('url_attr', ['array']);
+
     }
 
     private static function wrapValues(array $values)

--- a/src/Extension/Core/ColumnType/ColumnType.php
+++ b/src/Extension/Core/ColumnType/ColumnType.php
@@ -18,7 +18,6 @@ use Rollerworks\Component\Datagrid\Column\HeaderView;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\SingleMappingTransformer;
 use Rollerworks\Component\Datagrid\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ColumnType implements ColumnTypeInterface
 {
@@ -29,21 +28,9 @@ class ColumnType implements ColumnTypeInterface
     {
         $resolver->setRequired(['field_mapping', 'label']);
         $resolver->setDefaults(['field_mapping_single' => true]);
-
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'label' => 'string',
-                    'field_mapping' => 'array',
-                    'field_mapping_single' => 'bool',
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('label', 'string');
-            $resolver->setAllowedTypes('field_mapping', 'array');
-            $resolver->setAllowedTypes('field_mapping_single', 'bool');
-        }
+        $resolver->setAllowedTypes('label', 'string');
+        $resolver->setAllowedTypes('field_mapping', 'array');
+        $resolver->setAllowedTypes('field_mapping_single', 'bool');
     }
 
     /**

--- a/src/Extension/Core/ColumnType/CompoundColumnType.php
+++ b/src/Extension/Core/ColumnType/CompoundColumnType.php
@@ -16,7 +16,6 @@ use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Exception\UnexpectedTypeException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * CompoundColumn allows multiple sub-columns for advanced view building.
@@ -42,18 +41,8 @@ class CompoundColumnType extends AbstractColumnType
 
         // Not used but required by the ResolvedColumnType
         $resolver->setDefaults(['field_mapping' => []]);
-
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'label' => 'string',
-                    'columns' => 'array',
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('label', 'string');
-            $resolver->setAllowedTypes('columns', 'array');
-        }
+        $resolver->setAllowedTypes('label', 'string');
+        $resolver->setAllowedTypes('columns', 'array');
     }
 
     /**

--- a/src/Extension/Core/ColumnType/DateTimeType.php
+++ b/src/Extension/Core/ColumnType/DateTimeType.php
@@ -19,7 +19,6 @@ use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\StringToDateTi
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\TimestampToDateTimeTransformer;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * DateTimeType.
@@ -105,29 +104,11 @@ class DateTimeType extends AbstractColumnType
             'format' => null,
         ]);
 
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'input' => ['array', 'string'],
-                    'model_timezone' => ['null', 'string'],
-                    'view_timezone' => ['null', 'string'],
-                    'date_format' => ['null', 'string', 'integer'],
-                    'format' => ['null', 'string'],
-                ]
-            );
-
-            $resolver->setAllowedValues(
-                [
-                    'input' => ['string', 'timestamp', 'datetime', 'array'],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('input', ['array', 'string']);
-            $resolver->setAllowedTypes('model_timezone', ['null', 'string']);
-            $resolver->setAllowedTypes('view_timezone', ['null', 'string']);
-            $resolver->setAllowedTypes('date_format', ['null', 'string', 'integer']);
-            $resolver->setAllowedTypes('format', ['null', 'string']);
-            $resolver->setAllowedValues('input', ['string', 'timestamp', 'datetime', 'array']);
-        }
+        $resolver->setAllowedTypes('input', ['array', 'string']);
+        $resolver->setAllowedTypes('model_timezone', ['null', 'string']);
+        $resolver->setAllowedTypes('view_timezone', ['null', 'string']);
+        $resolver->setAllowedTypes('date_format', ['null', 'string', 'integer']);
+        $resolver->setAllowedTypes('format', ['null', 'string']);
+        $resolver->setAllowedValues('input', ['string', 'timestamp', 'datetime', 'array']);
     }
 }

--- a/src/Extension/Core/ColumnType/ModelType.php
+++ b/src/Extension/Core/ColumnType/ModelType.php
@@ -19,7 +19,6 @@ use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\TrimTransforme
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\ValueFormatTransformer;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
@@ -95,31 +94,14 @@ class ModelType extends AbstractColumnType
         ]);
 
         $resolver->setRequired(['model_fields']);
-
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'model_trim' => 'bool',
-                    'model_value_glue' => ['string', 'null'],
-                    'model_value_format' => ['string', 'callable', 'null'],
-                    'model_fields' => ['array'],
-                    'model_empty_value' => ['string', 'null'],
-                    'trim' => 'bool',
-                    'value_glue' => ['string', 'null'],
-                    'value_format' => ['string', 'callable', 'null'],
-                    'empty_value' => ['string', 'null'],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('model_trim', 'bool');
-            $resolver->setAllowedTypes('model_value_glue', ['string', 'null']);
-            $resolver->setAllowedTypes('model_value_format', ['string', 'callable', 'null']);
-            $resolver->setAllowedTypes('model_fields', ['array']);
-            $resolver->setAllowedTypes('model_empty_value', ['string', 'null']);
-            $resolver->setAllowedTypes('trim', 'bool');
-            $resolver->setAllowedTypes('value_glue', ['string', 'null']);
-            $resolver->setAllowedTypes('value_format', ['string', 'callable', 'null']);
-            $resolver->setAllowedTypes('empty_value', ['string', 'null']);
-        }
+        $resolver->setAllowedTypes('model_trim', 'bool');
+        $resolver->setAllowedTypes('model_value_glue', ['string', 'null']);
+        $resolver->setAllowedTypes('model_value_format', ['string', 'callable', 'null']);
+        $resolver->setAllowedTypes('model_fields', ['array']);
+        $resolver->setAllowedTypes('model_empty_value', ['string', 'null']);
+        $resolver->setAllowedTypes('trim', 'bool');
+        $resolver->setAllowedTypes('value_glue', ['string', 'null']);
+        $resolver->setAllowedTypes('value_format', ['string', 'callable', 'null']);
+        $resolver->setAllowedTypes('empty_value', ['string', 'null']);
     }
 }

--- a/src/Extension/Core/ColumnType/NumberType.php
+++ b/src/Extension/Core/ColumnType/NumberType.php
@@ -15,7 +15,6 @@ use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class NumberType extends AbstractColumnType
 {
@@ -43,33 +42,17 @@ class NumberType extends AbstractColumnType
             'rounding_mode' => \NumberFormatter::ROUND_HALFUP,
         ]);
 
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedValues(
-                [
-                    'rounding_mode' => [
-                        \NumberFormatter::ROUND_FLOOR,
-                        \NumberFormatter::ROUND_DOWN,
-                        \NumberFormatter::ROUND_HALFDOWN,
-                        \NumberFormatter::ROUND_HALFEVEN,
-                        \NumberFormatter::ROUND_HALFUP,
-                        \NumberFormatter::ROUND_UP,
-                        \NumberFormatter::ROUND_CEILING,
-                    ],
-                ]
-            );
-        } else {
-            $resolver->setAllowedValues(
-                'rounding_mode',
-                [
-                    \NumberFormatter::ROUND_FLOOR,
-                    \NumberFormatter::ROUND_DOWN,
-                    \NumberFormatter::ROUND_HALFDOWN,
-                    \NumberFormatter::ROUND_HALFEVEN,
-                    \NumberFormatter::ROUND_HALFUP,
-                    \NumberFormatter::ROUND_UP,
-                    \NumberFormatter::ROUND_CEILING,
-                ]
-            );
-        }
+        $resolver->setAllowedValues(
+            'rounding_mode',
+            [
+                \NumberFormatter::ROUND_FLOOR,
+                \NumberFormatter::ROUND_DOWN,
+                \NumberFormatter::ROUND_HALFDOWN,
+                \NumberFormatter::ROUND_HALFEVEN,
+                \NumberFormatter::ROUND_HALFUP,
+                \NumberFormatter::ROUND_UP,
+                \NumberFormatter::ROUND_CEILING,
+            ]
+        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | no |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |

Drop support for Symfony 2.3 OptionsResolver and allow Symfony 3 to installed.
