### PR TITLE
Rename namespaces and methods to reduce redandent naming

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,8 @@ UPGRADE
 
 ## Upgrade FROM 0.7 to 0.8
 
-This version contains BC breaking changes, older versions are no longer supported.
+This version contains some major BC breaking changes and introduces improvements
+and clean-ups.
 
  * Data binding support is removed. Instead you need process any data before setting data
    on the Datagrid.
@@ -15,6 +16,24 @@ This version contains BC breaking changes, older versions are no longer supporte
    will be used unless any of your composer.json packages restricts this version.
 
 ### Columns
+
+ * The `Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType` namespace is
+   renamed to `Rollerworks\Component\Datagrid\Tests\Extension\Core\Type`.
+
+ * The `Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnTypeExtension` namespace is
+   renamed to `Rollerworks\Component\Datagrid\Tests\Extension\Core\TypeExtension`.
+
+ * Class `Rollerworks\Component\Datagrid\Column\AbstractColumnTypeExtension` is renamed to
+   `Rollerworks\Component\Datagrid\Column\AbstractTypeExtension`.
+
+ * Class `Rollerworks\Component\Datagrid\Column\AbstractColumnType` is renamed to
+   `Rollerworks\Component\Datagrid\Column\AbstractType`.
+
+ * Methods of the `Rollerworks\Component\Datagrid\AbstractDatagridExtension` class and
+   `Rollerworks\Component\Datagrid\DatagridExtensionInterface` no longer contain the word `Column`.
+   For example `getColumnType` becomes to `getType`, `loadColumnTypes` becomes `loadTypes`.
+
+   *The reason behind this is redundancy, there are no other types in the datagrid then column types.*
 
  * A Column instance is no longer linked to a Datagrid instance.
    You can still use the Datagrid information when building the Header and Cell view of a column.
@@ -37,7 +56,7 @@ This version contains BC breaking changes, older versions are no longer supporte
    After:
 
    ```php
-   use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+   use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 
    $datagridBuilder->add('name', TextType::class, ['label' => 'Name']);
    ```
@@ -63,7 +82,7 @@ This version contains BC breaking changes, older versions are no longer supporte
    After:
 
    ```php
-   class UserProfileType extends AbstractColumnType
+   class UserProfileType extends AbstractType
    {
        public function getBlockPrefix()
        {
@@ -76,7 +95,7 @@ This version contains BC breaking changes, older versions are no longer supporte
    without "Type" suffix in underscore notation (here: "user_profile").
 
    Type extension should return the fully-qualified class name of the extended
-   type from `ColumnTypeExtensionInterface::getExtendedType()` now.
+   type from `TypeExtensionInterface::getExtendedType()` now.
 
    Before:
 
@@ -93,9 +112,9 @@ This version contains BC breaking changes, older versions are no longer supporte
    After:
 
    ```php
-   use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CoumnType;
+   use Rollerworks\Component\Datagrid\Extension\Core\Type\CoumnType;
 
-   class MyTypeExtension extends AbstractColumnTypeExtension
+   class MyTypeExtension extends AbstractTypeExtension
    {
        public function getExtendedType()
        {
@@ -122,7 +141,7 @@ This version contains BC breaking changes, older versions are no longer supporte
    After:
 
    ```php
-   class MyType extends AbstractColumnType
+   class MyType extends AbstractType
    {
        public function getParent()
        {
@@ -192,7 +211,7 @@ This version contains BC breaking changes, older versions are no longer supporte
    > ```
 
  * `Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ModelType` is removed.
-    Instead you can use the `Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextTypeType` with multiple
+    Instead you can use the `Rollerworks\Component\Datagrid\Extension\Core\Type\TextTypeType` with multiple
     fields returned by the "data_provider" and the "value_format" option set to a callback.
     And no "glue" set, the "value_format" as callback will receive all the fields allowing to fully customize
     the returned format.

--- a/src/AbstractDatagridExtension.php
+++ b/src/AbstractDatagridExtension.php
@@ -26,65 +26,65 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      *
      * @var array
      */
-    private $columnTypesExtensions;
+    private $typesExtensions;
 
     /**
      * All column types provided by extension.
      *
      * @var array
      */
-    private $columnTypes;
+    private $types;
 
     /**
      * {@inheritdoc}
      */
-    public function getColumnType($type)
+    public function getType($type)
     {
-        if (null === $this->columnTypes) {
+        if (null === $this->types) {
             $this->initColumnTypes();
         }
 
-        if (!isset($this->columnTypes[$type])) {
+        if (!isset($this->types[$type])) {
             throw new InvalidArgumentException(sprintf('Column type "%s" can not be loaded by this extension.', $type));
         }
 
-        return $this->columnTypes[$type];
+        return $this->types[$type];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasColumnType($type)
+    public function hasType($type)
     {
-        if (null === $this->columnTypes) {
+        if (null === $this->types) {
             $this->initColumnTypes();
         }
 
-        return isset($this->columnTypes[$type]);
+        return isset($this->types[$type]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasColumnTypeExtensions($type)
+    public function hasTypeExtensions($type)
     {
-        if (null === $this->columnTypesExtensions) {
-            $this->initColumnTypesExtensions();
+        if (null === $this->typesExtensions) {
+            $this->initTypesExtensions();
         }
 
-        return isset($this->columnTypesExtensions[$type]);
+        return isset($this->typesExtensions[$type]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getColumnTypeExtensions($type)
+    public function getTypeExtensions($type)
     {
-        if (null === $this->columnTypesExtensions) {
-            $this->initColumnTypesExtensions();
+        if (null === $this->typesExtensions) {
+            $this->initTypesExtensions();
         }
 
-        return isset($this->columnTypesExtensions[$type]) ? $this->columnTypesExtensions[$type] : [];
+        return isset($this->typesExtensions[$type]) ? $this->typesExtensions[$type] : [];
     }
 
     /**
@@ -103,7 +103,7 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      *
      * @codeCoverageIgnore
      */
-    protected function loadColumnTypes()
+    protected function loadTypes()
     {
         return [];
     }
@@ -123,14 +123,14 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
 
     /**
      * If extension needs to provide new column types this function
-     * should be overloaded in child class and return array of DatagridColumnTypeInterface
+     * should be overloaded in child class and return array of ColumnTypeInterface
      * instances.
      *
      * @return array
      *
      * @codeCoverageIgnore
      */
-    protected function loadColumnTypesExtensions()
+    protected function loadTypesExtensions()
     {
         return [];
     }
@@ -140,32 +140,32 @@ abstract class AbstractDatagridExtension implements DatagridExtensionInterface
      */
     private function initColumnTypes()
     {
-        $this->columnTypes = [];
+        $this->types = [];
 
-        foreach ($this->loadColumnTypes() as $type) {
+        foreach ($this->loadTypes() as $type) {
             if (!$type instanceof ColumnTypeInterface) {
                 throw new UnexpectedTypeException($type, ColumnTypeInterface::class);
             }
 
-            $this->columnTypes[get_class($type)] = $type;
+            $this->types[get_class($type)] = $type;
         }
     }
 
     /**
      * @throws UnexpectedTypeException
      */
-    private function initColumnTypesExtensions()
+    private function initTypesExtensions()
     {
-        $this->columnTypesExtensions = [];
+        $this->typesExtensions = [];
 
-        foreach ($this->loadColumnTypesExtensions() as $extension) {
+        foreach ($this->loadTypesExtensions() as $extension) {
             if (!$extension instanceof ColumnTypeExtensionInterface) {
                 throw new UnexpectedTypeException($extension, ColumnTypeExtensionInterface::class);
             }
 
             $type = $extension->getExtendedType();
 
-            $this->columnTypesExtensions[$type][] = $extension;
+            $this->typesExtensions[$type][] = $extension;
         }
     }
 }

--- a/src/Column/AbstractType.php
+++ b/src/Column/AbstractType.php
@@ -11,14 +11,14 @@
 
 namespace Rollerworks\Component\Datagrid\Column;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\ColumnType;
 use Rollerworks\Component\Datagrid\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class AbstractColumnType implements ColumnTypeInterface
+abstract class AbstractType implements ColumnTypeInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Column/AbstractTypeExtension.php
+++ b/src/Column/AbstractTypeExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscaps.net>
  */
-abstract class AbstractColumnTypeExtension implements ColumnTypeExtensionInterface
+abstract class AbstractTypeExtension implements ColumnTypeExtensionInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Column/ColumnTypeRegistry.php
+++ b/src/Column/ColumnTypeRegistry.php
@@ -67,8 +67,8 @@ class ColumnTypeRegistry implements ColumnTypeRegistryInterface
             $type = null;
 
             foreach ($this->extensions as $extension) {
-                if ($extension->hasColumnType($name)) {
-                    $type = $extension->getColumnType($name);
+                if ($extension->hasType($name)) {
+                    $type = $extension->getType($name);
 
                     break;
                 }
@@ -133,7 +133,7 @@ class ColumnTypeRegistry implements ColumnTypeRegistryInterface
         foreach ($this->extensions as $extension) {
             $typeExtensions = array_merge(
                 $typeExtensions,
-                $extension->getColumnTypeExtensions($fqcn)
+                $extension->getTypeExtensions($fqcn)
             );
         }
 

--- a/src/DatagridExtensionInterface.php
+++ b/src/DatagridExtensionInterface.php
@@ -34,7 +34,7 @@ interface DatagridExtensionInterface
      *
      * @return bool
      */
-    public function hasColumnType($type);
+    public function hasType($type);
 
     /**
      * Get column type.
@@ -45,7 +45,7 @@ interface DatagridExtensionInterface
      *
      * @return ColumnTypeInterface
      */
-    public function getColumnType($type);
+    public function getType($type);
 
     /**
      * Check if extension has any column type extension for column of $type.
@@ -54,7 +54,7 @@ interface DatagridExtensionInterface
      *
      * @return bool
      */
-    public function hasColumnTypeExtensions($type);
+    public function hasTypeExtensions($type);
 
     /**
      * Return extensions for column type provided by this data grid extension.
@@ -63,5 +63,5 @@ interface DatagridExtensionInterface
      *
      * @return ColumnTypeExtensionInterface[]
      */
-    public function getColumnTypeExtensions($type);
+    public function getTypeExtensions($type);
 }

--- a/src/Extension/Core/CoreExtension.php
+++ b/src/Extension/Core/CoreExtension.php
@@ -22,32 +22,32 @@ class CoreExtension extends AbstractDatagridExtension
     /**
      * {@inheritdoc}
      */
-    protected function loadColumnTypes()
+    protected function loadTypes()
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         return [
-            new ColumnType\ColumnType($propertyAccessor),
-            new ColumnType\CompoundColumnType(),
+            new Type\ColumnType($propertyAccessor),
+            new Type\CompoundColumnType(),
 
-            new ColumnType\ActionType(),
-            new ColumnType\BatchType(),
-            new ColumnType\BooleanType(),
-            new ColumnType\DateTimeType(),
-            new ColumnType\MoneyType(),
-            new ColumnType\NumberType(),
-            new ColumnType\TextType(),
+            new Type\ActionType(),
+            new Type\BatchType(),
+            new Type\BooleanType(),
+            new Type\DateTimeType(),
+            new Type\MoneyType(),
+            new Type\NumberType(),
+            new Type\TextType(),
         ];
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function loadColumnTypesExtensions()
+    protected function loadTypesExtensions()
     {
         return [
-            new ColumnTypeExtension\ColumnOrderExtension(),
-            new ColumnTypeExtension\CompoundColumnOrderExtension(),
+            new TypeExtension\ColumnOrderExtension(),
+            new TypeExtension\CompoundColumnOrderExtension(),
         ];
     }
 

--- a/src/Extension/Core/Type/ActionType.php
+++ b/src/Extension/Core/Type/ActionType.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author FSi sp. z o.o. <info@fsi.pl>
  */
-class ActionType extends AbstractColumnType
+class ActionType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/Type/BatchType.php
+++ b/src/Extension/Core/Type/BatchType.php
@@ -9,14 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Column\HeaderView;
 
-class BatchType extends AbstractColumnType
+class BatchType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/Type/BooleanType.php
+++ b/src/Extension/Core/Type/BooleanType.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author FSi sp. z o.o. <info@fsi.pl>
  */
-class BooleanType extends AbstractColumnType
+class BooleanType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/Type/ColumnType.php
+++ b/src/Extension/Core/Type/ColumnType.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;

--- a/src/Extension/Core/Type/CompoundColumnType.php
+++ b/src/Extension/Core/Type/CompoundColumnType.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Exception\UnexpectedTypeException;
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class CompoundColumnType extends AbstractColumnType
+class CompoundColumnType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\ArrayToDateTimeTransformer;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
@@ -27,7 +27,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  */
-class DateTimeType extends AbstractColumnType
+class DateTimeType extends AbstractType
 {
     const DEFAULT_DATE_FORMAT = \IntlDateFormatter::MEDIUM;
     const DEFAULT_TIME_FORMAT = \IntlDateFormatter::MEDIUM;

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class MoneyType extends AbstractColumnType
+class MoneyType extends AbstractType
 {
     public function buildColumn(ColumnInterface $column, array $options)
     {

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -9,14 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class NumberType extends AbstractColumnType
+class NumberType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/Type/TextType.php
+++ b/src/Extension/Core/Type/TextType.php
@@ -9,15 +9,15 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnType;
+use Rollerworks\Component\Datagrid\Column\AbstractType;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\EmptyValueTransformer;
 use Rollerworks\Component\Datagrid\Extension\Core\DataTransformer\ValueFormatTransformer;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TextType extends AbstractColumnType
+class TextType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/TypeExtension/ColumnOrderExtension.php
+++ b/src/Extension/Core/TypeExtension/ColumnOrderExtension.php
@@ -9,12 +9,12 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnTypeExtension;
+namespace Rollerworks\Component\Datagrid\Extension\Core\TypeExtension;
 
-use Rollerworks\Component\Datagrid\Column\AbstractColumnTypeExtension;
+use Rollerworks\Component\Datagrid\Column\AbstractTypeExtension;
 use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\Column\HeaderView;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\ColumnType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ColumnOrderExtension extends AbstractColumnTypeExtension
+class ColumnOrderExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Extension/Core/TypeExtension/CompoundColumnOrderExtension.php
+++ b/src/Extension/Core/TypeExtension/CompoundColumnOrderExtension.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Extension\Core\ColumnTypeExtension;
+namespace Rollerworks\Component\Datagrid\Extension\Core\TypeExtension;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CompoundColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\CompoundColumnType;
 
 /**
  * Allows to set the compound-column sorting order.

--- a/src/PreloadedExtension.php
+++ b/src/PreloadedExtension.php
@@ -44,7 +44,7 @@ class PreloadedExtension implements DatagridExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnType($name)
+    public function getType($name)
     {
         if (!isset($this->columnTypes[$name])) {
             throw new InvalidArgumentException(
@@ -58,7 +58,7 @@ class PreloadedExtension implements DatagridExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function hasColumnType($name)
+    public function hasType($name)
     {
         return isset($this->columnTypes[$name]);
     }
@@ -66,7 +66,7 @@ class PreloadedExtension implements DatagridExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnTypeExtensions($name)
+    public function getTypeExtensions($name)
     {
         return isset($this->typeColumnExtensions[$name]) ? $this->typeColumnExtensions[$name] : [];
     }
@@ -74,7 +74,7 @@ class PreloadedExtension implements DatagridExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function hasColumnTypeExtensions($name)
+    public function hasTypeExtensions($name)
     {
         return !empty($this->typeColumnExtensions[$name]);
     }

--- a/tests/DatagridBuilderTest.php
+++ b/tests/DatagridBuilderTest.php
@@ -15,8 +15,8 @@ use Rollerworks\Component\Datagrid\Column\ColumnInterface;
 use Rollerworks\Component\Datagrid\DatagridBuilder;
 use Rollerworks\Component\Datagrid\DatagridFactoryInterface;
 use Rollerworks\Component\Datagrid\DatagridInterface;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 
 final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/DatagridFactoryTest.php
+++ b/tests/DatagridFactoryTest.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface;
 use Rollerworks\Component\Datagrid\DatagridBuilderInterface;
 use Rollerworks\Component\Datagrid\DatagridFactory;
 use Rollerworks\Component\Datagrid\DatagridInterface;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 
 class DatagridFactoryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/DatagridPerformanceTest.php
+++ b/tests/DatagridPerformanceTest.php
@@ -12,9 +12,9 @@
 namespace Rollerworks\Component\Datagrid\Tests;
 
 use Rollerworks\Component\Datagrid\DatagridViewInterface;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\DateTimeType;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\DateTimeType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 use Rollerworks\Component\Datagrid\Test\DatagridPerformanceTestCase;
 
 class DatagridPerformanceTest extends DatagridPerformanceTestCase

--- a/tests/DatagridTest.php
+++ b/tests/DatagridTest.php
@@ -17,7 +17,7 @@ use Rollerworks\Component\Datagrid\Column\HeaderView;
 use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeInterface;
 use Rollerworks\Component\Datagrid\Datagrid;
 use Rollerworks\Component\Datagrid\DatagridViewInterface;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 use Rollerworks\Component\Datagrid\Tests\Fixtures\Entity;
 use Rollerworks\Component\Datagrid\Util\StringUtil;
 

--- a/tests/Extension/Core/Type/ActionTypeTest.php
+++ b/tests/Extension/Core/Type/ActionTypeTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ActionType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\ActionType;
 
 class ActionTypeTest extends BaseTypeTest
 {

--- a/tests/Extension/Core/Type/BaseTypeTest.php
+++ b/tests/Extension/Core/Type/BaseTypeTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
 use Rollerworks\Component\Datagrid\Test\ColumnTypeTestCase;
 

--- a/tests/Extension/Core/Type/BooleanTest.php
+++ b/tests/Extension/Core/Type/BooleanTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\BooleanType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\BooleanType;
 
 class BooleanTest extends BaseTypeTest
 {

--- a/tests/Extension/Core/Type/ColumnTypeTest.php
+++ b/tests/Extension/Core/Type/ColumnTypeTest.php
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
 use Rollerworks\Component\Datagrid\Exception\DataProviderException;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\ColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\ColumnType;
 
 class ColumnTypeTest extends BaseTypeTest
 {

--- a/tests/Extension/Core/Type/CompoundColumnTypeTest.php
+++ b/tests/Extension/Core/Type/CompoundColumnTypeTest.php
@@ -9,13 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
 use Rollerworks\Component\Datagrid\Column\CellView;
 use Rollerworks\Component\Datagrid\Exception\UnexpectedTypeException;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\CompoundColumnType;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\CompoundColumnType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 
 class CompoundColumnTypeTest extends BaseTypeTest
 {

--- a/tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\DateTimeType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTimeTypeTest extends BaseTypeTest

--- a/tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Extension/Core/Type/MoneyTypeTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\MoneyType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\MoneyType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyTypeTest extends BaseTypeTest

--- a/tests/Extension/Core/Type/NumberTypeTest.php
+++ b/tests/Extension/Core/Type/NumberTypeTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\NumberType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\NumberType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class NumberTypeTest extends BaseTypeTest

--- a/tests/Extension/Core/Type/TextTypeTest.php
+++ b/tests/Extension/Core/Type/TextTypeTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\ColumnType;
+namespace Rollerworks\Component\Datagrid\Tests\Extension\Core\Type;
 
-use Rollerworks\Component\Datagrid\Extension\Core\ColumnType\TextType;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\TextType;
 
 class TextTypeTest extends BaseTypeTest
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | no |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |

There are no other types in the datagrid then column types. So it's redundant to include Column for types.
