### PR TITLE
Fix to-strict version requirement for option-resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~5.5|~7.0",
         "symfony/property-access": "~2.8|~3.0",
-        "symfony/options-resolver": "~2.7.7|~3.0",
+        "symfony/options-resolver": "^2.7.7|~3.0",
         "symfony/intl": "~2.3|~3.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | no |
| BC Breaks? | no |
| Deprecations? | no |
| Fixed Tickets |  |

The minimum version is 2.7.7, but should not be restricted to Symfony 2.7 only!!
