### PR TITLE
Introduce Datagrids for creating DatagridFactories

### DIFF
--- a/src/Column/ColumnTypeRegistry.php
+++ b/src/Column/ColumnTypeRegistry.php
@@ -44,7 +44,7 @@ class ColumnTypeRegistry implements ColumnTypeRegistryInterface
      * Constructor.
      *
      * @param DatagridExtensionInterface[]       $extensions          An array of DatagridExtensionInterface
-     * @param ResolvedColumnTypeFactoryInterface $resolvedTypeFactory The factory for resolved form types
+     * @param ResolvedColumnTypeFactoryInterface $resolvedTypeFactory The factory for resolved column types
      *
      * @throws UnexpectedTypeException if an extension does not implement DatagridExtensionInterface
      */

--- a/src/Column/ResolvedColumnTypeInterface.php
+++ b/src/Column/ResolvedColumnTypeInterface.php
@@ -40,7 +40,7 @@ interface ResolvedColumnTypeInterface
     /**
      * Returns the wrapped column type.
      *
-     * @return ColumnTypeInterface The wrapped form type
+     * @return ColumnTypeInterface The wrapped column type
      */
     public function getInnerType(): ColumnTypeInterface;
 

--- a/src/Datagrids.php
+++ b/src/Datagrids.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksDatagrid package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Datagrid;
+
+use Rollerworks\Component\Datagrid\Extension\Core\CoreExtension;
+use Rollerworks\Component\Datagrid\Util\DatagridFactoryBuilder;
+
+/**
+ * Entry point of the Datagrid system.
+ *
+ * *You should not use this class when integrating the Datagrid system
+ * with a Framework that supports Dependency Injection.*
+ *
+ * Use this class to conveniently create new datagrid factories:
+ *
+ * <code>
+ * use Rollerworks\Component\Datagrid\Datagrids;
+ * use Rollerworks\Component\Datagrid\Extension\Core\Type as ColumnType;
+ *
+ * $datagridFactory = Datagrids::createDatagridFactory();
+ *
+ * $datagrid = $datagridFactory->createDatagridBuilder()
+ *    ->add('id', ColumnType\NumberType::class)
+ *    ->add('username', ColumnType\TextType::class)
+ *    ->add('registered_on', ColumnType\DateTimeType::class)
+ *    ->add('enabled', ColumnType\BooleanType::class, ['true_value' => 'Yes', 'false_value' => 'No'])
+ *    ->getDatagrid('users_datagrid')
+ * ;
+ * </code>
+ *
+ * You can also add custom extensions to the datagrid factory:
+ *
+ * <code>
+ * $datagridFactory = Datagrids::createDatagridFactoryBuilder();
+ *     ->addExtension(new AcmeExtension())
+ *     ->getDatagridFactory()
+ * ;
+ * </code>
+ *
+ * If you create custom types, it is not required to register them
+ * as they will be be automatically loaded by there FQCN
+ * `Acme\Datagrid\Type\PhoneNumberType`.
+ *
+ * But when they have external dependencies you need to register them
+ * manually. It's recommended to create your own extensions that lazily
+ * loads these types and type extensions.
+ *
+ * When there are no performance problems, you can also pass them directly
+ * to the datagrid factory:
+ *
+ * <code>
+ * use Rollerworks\Component\Datagrid\Datagrids;
+ *
+ * $datagridFactory = Datagrids::createDatagridFactoryBuilder();
+ *     ->addType(new PhoneNumberType())
+ *     ->addTypeExtension(new GedmoExtension())
+ *     ->getDatagridFactory()
+ * ;
+ * </code>
+ *
+ * **Note:** Type extensions are not loaded automatically, you must always register them.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class Datagrids
+{
+    /**
+     * Creates a DatagridFactory builder with the default configuration.
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public static function createDatagridFactoryBuilder(): DatagridFactoryBuilder
+    {
+        $builder = new DatagridFactoryBuilder();
+        $builder->addExtension(new CoreExtension());
+
+        return $builder;
+    }
+
+    /**
+     * @return DatagridFactory
+     */
+    public static function createDatagridFactory(): DatagridFactory
+    {
+        $builder = new DatagridFactoryBuilder();
+        $builder->addExtension(new CoreExtension());
+
+        return $builder->getDatagridFactory();
+    }
+
+    /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/PreloadedExtension.php
+++ b/src/PreloadedExtension.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Datagrid;
 
-use Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface;
 use Rollerworks\Component\Datagrid\Column\ColumnTypeInterface;
 use Rollerworks\Component\Datagrid\Exception\InvalidArgumentException;
 
@@ -25,10 +24,11 @@ class PreloadedExtension implements DatagridExtensionInterface
     /**
      * Constructor.
      *
-     * @param ColumnTypeInterface[]          $types          The column-types that the extension
-     *                                                       should support
-     * @param ColumnTypeExtensionInterface[] $typeExtensions The column-type extensions that the extension
-     *                                                       should support
+     * @param ColumnTypeInterface[] $types          The column-types that the extension
+     *                                              should support
+     * @param array[]               $typeExtensions The column-type extensions that the extension
+     *                                              should support.
+     *                                              Registered as [type => [ColumnTypeExtensionInterface object, ...]]
      */
     public function __construct(array $types, array $typeExtensions)
     {

--- a/src/Util/DatagridFactoryBuilder.php
+++ b/src/Util/DatagridFactoryBuilder.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksDatagrid package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Datagrid\Util;
+
+use Rollerworks\Component\Datagrid\Column\ColumnTypeExtensionInterface;
+use Rollerworks\Component\Datagrid\Column\ColumnTypeInterface;
+use Rollerworks\Component\Datagrid\Column\ColumnTypeRegistry;
+use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeFactory;
+use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeFactoryInterface;
+use Rollerworks\Component\Datagrid\DatagridExtensionInterface;
+use Rollerworks\Component\Datagrid\DatagridFactory;
+use Rollerworks\Component\Datagrid\PreloadedExtension;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class DatagridFactoryBuilder
+{
+    private $resolvedTypeFactory;
+    private $extensions = [];
+    private $types = [];
+    private $typeExtensions = [];
+
+    /**
+     * @param ResolvedColumnTypeFactoryInterface $resolvedTypeFactory
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function setResolvedTypeFactory(ResolvedColumnTypeFactoryInterface $resolvedTypeFactory): self
+    {
+        $this->resolvedTypeFactory = $resolvedTypeFactory;
+
+        return $this;
+    }
+
+    /**
+     * @param DatagridExtensionInterface $extension
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addExtension(DatagridExtensionInterface $extension): self
+    {
+        $this->extensions[] = $extension;
+
+        return $this;
+    }
+
+    /**
+     * @param DatagridExtensionInterface[] $extensions
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addExtensions($extensions): self
+    {
+        $this->extensions = array_merge($this->extensions, $extensions);
+
+        return $this;
+    }
+
+    /**
+     * @param ColumnTypeInterface $type
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addType(ColumnTypeInterface $type): self
+    {
+        $this->types[get_class($type)] = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param ColumnTypeInterface[] $types
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addTypes(array $types): self
+    {
+        foreach ($types as $type) {
+            $this->types[get_class($type)] = $type;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param ColumnTypeExtensionInterface $typeExtension
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addTypeExtension(ColumnTypeExtensionInterface $typeExtension): self
+    {
+        $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
+
+        return $this;
+    }
+
+    /**
+     * @param ColumnTypeExtensionInterface[] $typeExtensions
+     *
+     * @return DatagridFactoryBuilder
+     */
+    public function addTypeExtensions(array $typeExtensions): self
+    {
+        foreach ($typeExtensions as $typeExtension) {
+            $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return DatagridFactory
+     */
+    public function getDatagridFactory(): DatagridFactory
+    {
+        $extensions = $this->extensions;
+
+        if (count($this->types) > 0 || count($this->typeExtensions) > 0) {
+            $extensions[] = new PreloadedExtension($this->types, $this->typeExtensions);
+        }
+
+        $registry = new ColumnTypeRegistry(
+            $extensions,
+            $this->resolvedTypeFactory ?: new ResolvedColumnTypeFactory()
+        );
+
+        return new DatagridFactory($registry);
+    }
+}

--- a/tests/DatagridsTest.php
+++ b/tests/DatagridsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksDatagrid package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Datagrid\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Datagrid\Datagrids;
+use Rollerworks\Component\Datagrid\Extension\Core\Type as ColumnType;
+
+final class DatagridsTest extends TestCase
+{
+    /** @test */
+    public function creates_a_datagrid_factory()
+    {
+        $datagridFactory = Datagrids::createDatagridFactory();
+
+        $datagrid = $datagridFactory->createDatagridBuilder()
+            ->add('id', ColumnType\NumberType::class)
+            ->add('username', ColumnType\TextType::class)
+            ->add('registered_on', ColumnType\DateTimeType::class)
+            ->add('enabled', ColumnType\BooleanType::class, ['true_value' => 'Yes', 'false_value' => 'No'])
+            ->getDatagrid('users_datagrid')
+        ;
+
+        // Dummy test, once the Datagrid is generated all is well.
+        self::assertEquals('users_datagrid', $datagrid->getName());
+    }
+
+    /** @test */
+    public function creates_a_datagrid_factory_builder()
+    {
+        $datagridFactory = Datagrids::createDatagridFactoryBuilder()->getDatagridFactory();
+
+        $datagrid = $datagridFactory->createDatagridBuilder()
+            ->add('id', ColumnType\NumberType::class)
+            ->add('username', ColumnType\TextType::class)
+            ->add('registered_on', ColumnType\DateTimeType::class)
+            ->add('enabled', ColumnType\BooleanType::class, ['true_value' => 'Yes', 'false_value' => 'No'])
+            ->getDatagrid('users_datagrid')
+        ;
+
+        // Dummy test, once the Datagrid is generated all is well.
+        self::assertEquals('users_datagrid', $datagrid->getName());
+    }
+}

--- a/tests/Util/DatagridFactoryBuilderTest.php
+++ b/tests/Util/DatagridFactoryBuilderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksDatagrid package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Datagrid\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Datagrid\Column\ColumnTypeRegistry;
+use Rollerworks\Component\Datagrid\Column\ResolvedColumnTypeFactoryInterface;
+use Rollerworks\Component\Datagrid\Extension\Core\CoreExtension;
+use Rollerworks\Component\Datagrid\Extension\Core\Type\DateTimeType;
+use Rollerworks\Component\Datagrid\PreloadedExtension;
+use Rollerworks\Component\Datagrid\Tests\Fixtures\Extension\DateTypeExtension;
+use Rollerworks\Component\Datagrid\Tests\Fixtures\Extension\FooType;
+use Rollerworks\Component\Datagrid\Util\DatagridFactoryBuilder;
+
+final class DatagridFactoryBuilderTest extends TestCase
+{
+    /** @var \Rollerworks\Component\Datagrid\Util\DatagridFactoryBuilder */
+    private $builder;
+
+    /** @var ResolvedColumnTypeFactoryInterface */
+    private $resolvedColumnFactory;
+
+    /** @before */
+    public function setUpBuilder()
+    {
+        $this->resolvedColumnFactory = $this->createMock(ResolvedColumnTypeFactoryInterface::class);
+
+        $this->builder = new DatagridFactoryBuilder();
+        $this->builder->setResolvedTypeFactory($this->resolvedColumnFactory);
+        $this->builder->addExtension(new CoreExtension());
+        $this->builder->addType(new FooType());
+        $this->builder->addTypeExtension(new DateTypeExtension());
+    }
+
+    /** @test */
+    public function custom_resolvedColumnTypeFactory_is_used()
+    {
+        $factory = $this->builder->getDatagridFactory();
+
+        /** @var ColumnTypeRegistry $typeRegistry */
+        $typeRegistry = $this->extractObjectProperty($factory, 'typeRegistry');
+
+        self::assertSame(
+            $this->resolvedColumnFactory,
+            $this->extractObjectProperty($typeRegistry, 'resolvedTypeFactory')
+        );
+    }
+
+    /** @test */
+    public function extensions_types_are_registered()
+    {
+        $factory = $this->builder->getDatagridFactory();
+        /** @var ColumnTypeRegistry $typeRegistry */
+        $typeRegistry = $this->extractObjectProperty($factory, 'typeRegistry');
+
+        self::assertEquals(
+            [
+                new CoreExtension(),
+                new PreloadedExtension(
+                    [FooType::class => new FooType()],
+                    [DateTimeType::class => [new DateTypeExtension()]]
+                ),
+            ],
+            $typeRegistry->getExtensions()
+        );
+    }
+
+    /**
+     * Extract a property from an object.
+     *
+     * Normally you should not do this, but as this the only
+     * way to test if the object is properly build.
+     * Else the test would become overly complex.
+     *
+     * @param object $factory
+     *
+     * @return mixed
+     */
+    private function extractObjectProperty($factory, $name)
+    {
+        $func = function ($name) {
+            return $this->{$name};
+        };
+
+        $helper = $func->bindTo($factory, $factory);
+
+        return $helper($name);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | no |
| Deprecations? | no |
| Fixed Tickets | #8 |

The `Datagrids` class works a facade, it hides a great deal of the implementation details and makes it much easier
for none Framework users to create a DatagridFactory with custom extensions, types and type extensions.

I decided not to add an interface for the DatagridFactoryBuilder class as anyone
needing a custom implementation will use a fully custom implementation (KISS 😋).

Documentation is coming, but the PHPDoc should already explain how to use this.
