### PR TITLE
More flexible data_provider auto-configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -100,6 +100,10 @@ UPGRADE
   Precision is not used with integers, and keeping this argument only causes confusion.
   
 * The class `ColumnOrderExtension` and `CompoundColumnOrderExtension`.
+
+* The `data_provider` option of the `ColumnType` no longer supports any callable
+  but requires a `Closure` or `Symfony\Component\PropertyAccess\PropertyPath` object, or a string
+  with a valid property-path.
   
 ### DatagridBuilder
   

--- a/src/Exception/DataProviderException.php
+++ b/src/Exception/DataProviderException.php
@@ -13,14 +13,31 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Datagrid\Exception;
 
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
 final class DataProviderException extends \RuntimeException implements ExceptionInterface
 {
-    public static function autoAccessorUnableToGetValue(string $columnName, \Exception $previous = null)
+    public static function autoAccessorUnableToGetValue(string $columnName)
     {
         return new self(
-            sprintf('Unable to get value for column "%s". Consider setting the "data_provider" option.', $columnName),
+            sprintf('Unable to get value for column "%s". Consider setting the "data_provider" option.', $columnName)
+        );
+    }
+
+    public static function pathAccessorUnableToGetValue(string $columnName, PropertyPath $propertyPath)
+    {
+        return new self(
+            sprintf('Unable to get value for column "%s" with property-path "%s".', $columnName, (string) $propertyPath)
+        );
+    }
+
+    public static function invalidPropertyPath(string $columnName, InvalidPropertyPathException $e)
+    {
+        return new self(
+            sprintf('Invalid property-path for column "%s" with message: %s', $columnName, $e->getMessage()),
             1,
-            $previous
+            $e
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |

When the data_provider is not empty, and not a closure convert it to a PropertyPath.
There is a big change that a column is named eg. batch, but the actual field is ‘id’.
or name vs username.

There is a minor BC break, as the 'data_provider' no longer allows any callable
but requires an explicit `Closure`. Allowing any Callable could fail with existing
functions with the same name 😅.
